### PR TITLE
Create interactive liquid glass research portfolio

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,678 @@
+:root {
+  color-scheme: dark;
+  --bg-gradient: radial-gradient(circle at 20% 20%, rgba(0, 179, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(185, 111, 255, 0.28), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(71, 211, 255, 0.25), transparent 55%),
+    linear-gradient(160deg, #0b0f19 0%, #04070e 100%);
+  --glass-bg: rgba(15, 22, 38, 0.55);
+  --glass-border: rgba(255, 255, 255, 0.16);
+  --text-primary: #f5f7ff;
+  --text-secondary: rgba(245, 247, 255, 0.72);
+  --accent: #7ae3ff;
+  --accent-strong: #4ad7ff;
+  --shadow: 0 25px 70px rgba(4, 12, 34, 0.65);
+  --radius-lg: 28px;
+  --radius-sm: 16px;
+  --trans-fast: 180ms ease;
+  --trans-slow: 480ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Plus Jakarta Sans", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.aurora {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-gradient);
+  filter: blur(50px);
+  opacity: 0.8;
+  z-index: -2;
+}
+
+.hero {
+  padding: 2.5rem clamp(1.5rem, 4vw, 4rem) 0;
+  position: relative;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2.5rem;
+  backdrop-filter: blur(24px);
+  background: rgba(8, 13, 25, 0.35);
+  border: 1px solid rgba(122, 227, 255, 0.2);
+  border-radius: 999px;
+  padding: 0.8rem 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.logo {
+  font-weight: 700;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  color: var(--accent);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--text-secondary);
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  transition: background-color var(--trans-fast), color var(--trans-fast), transform var(--trans-fast);
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  background: rgba(122, 227, 255, 0.18);
+  color: var(--text-primary);
+  transform: translateY(-2px);
+}
+
+.nav-toggle {
+  display: none;
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(10, 16, 25, 0.5);
+  backdrop-filter: blur(20px);
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  transition: transform var(--trans-fast);
+}
+
+.nav-toggle span {
+  width: 20px;
+  height: 2px;
+  background: var(--text-primary);
+  border-radius: 999px;
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: stretch;
+}
+
+.glass {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(32px) saturate(160%);
+  border-radius: var(--radius-lg);
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--trans-slow), border-color var(--trans-fast), box-shadow var(--trans-slow);
+}
+
+.glass::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 45%);
+  pointer-events: none;
+}
+
+.glass:hover {
+  transform: translateY(-8px) scale(1.01);
+  border-color: rgba(122, 227, 255, 0.45);
+  box-shadow: 0 40px 90px rgba(8, 17, 35, 0.75);
+}
+
+.hero-card {
+  padding: clamp(2rem, 5vw, 3.5rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.bio-header {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.bio-header img {
+  width: clamp(110px, 20vw, 160px);
+  height: clamp(110px, 20vw, 160px);
+  border-radius: 28px;
+  object-fit: cover;
+  filter: saturate(110%);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.avatar-fallback {
+  width: clamp(110px, 20vw, 160px);
+  height: clamp(110px, 20vw, 160px);
+  border-radius: 28px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(122, 227, 255, 0.32), rgba(76, 89, 255, 0.28));
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--text-primary);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.bio-header h1 {
+  font-size: clamp(2.4rem, 4vw, 3rem);
+  font-weight: 700;
+}
+
+.bio-header h1 span {
+  display: block;
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  font-weight: 500;
+  color: var(--accent);
+}
+
+.bio-description {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+.socials {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.socials a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  background: rgba(122, 227, 255, 0.16);
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 500;
+  border: 1px solid rgba(122, 227, 255, 0.25);
+  transition: transform var(--trans-fast), background var(--trans-fast);
+}
+
+.socials a:hover {
+  transform: translateY(-2px) scale(1.02);
+  background: rgba(122, 227, 255, 0.28);
+}
+
+.map-card {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.map-card iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: calc(var(--radius-lg) - 12px);
+  min-height: 280px;
+}
+
+.section {
+  padding: clamp(3rem, 6vw, 5rem) clamp(1.5rem, 4vw, 4rem);
+}
+
+.section-header {
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-header h2 {
+  font-size: clamp(2rem, 3.8vw, 2.75rem);
+}
+
+.section-subtitle {
+  color: var(--text-secondary);
+  max-width: 540px;
+}
+
+.news-wrapper {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.news-column {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.news-card {
+  position: relative;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(122, 227, 255, 0.15);
+  padding: 1rem 1.2rem 1.2rem;
+  background: rgba(10, 18, 32, 0.55);
+  transition: transform var(--trans-fast), border-color var(--trans-fast);
+}
+
+.news-card:hover {
+  transform: translateX(6px);
+  border-color: rgba(122, 227, 255, 0.4);
+}
+
+.news-card time {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(122, 227, 255, 0.8);
+}
+
+.news-card p {
+  margin-top: 0.65rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(122, 227, 255, 0.18);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background var(--trans-fast), transform var(--trans-fast), border-color var(--trans-fast);
+}
+
+.chip:hover,
+.chip.active {
+  background: rgba(122, 227, 255, 0.32);
+  border-color: rgba(122, 227, 255, 0.4);
+  transform: translateY(-2px);
+}
+
+.timeline {
+  position: relative;
+  margin-inline: auto;
+  max-width: 900px;
+  padding-left: 1.5rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(122, 227, 255, 0.6), transparent);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+  padding-left: 2.5rem;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -2px;
+  top: 0.6rem;
+  width: 16px;
+  height: 16px;
+  background: linear-gradient(135deg, #7ae3ff, #4ad7ff);
+  border-radius: 50%;
+  box-shadow: 0 0 0 6px rgba(122, 227, 255, 0.1);
+}
+
+.timeline-card {
+  padding: 1.5rem 1.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(10, 18, 32, 0.65);
+  border: 1px solid rgba(122, 227, 255, 0.2);
+  transition: transform var(--trans-fast), border-color var(--trans-fast);
+}
+
+.timeline-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(122, 227, 255, 0.45);
+}
+
+.timeline-card h3 {
+  font-size: 1.15rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.timeline-card h3 a {
+  color: var(--accent);
+}
+
+.timeline-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0.75rem 0;
+  color: rgba(122, 227, 255, 0.8);
+  font-size: 0.9rem;
+}
+
+.timeline-card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.project-card,
+.achievement-card {
+  position: relative;
+  padding: 1.8rem;
+  border-radius: var(--radius-sm);
+  background: rgba(10, 18, 32, 0.6);
+  border: 1px solid rgba(122, 227, 255, 0.18);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform var(--trans-slow), border-color var(--trans-fast);
+}
+
+.project-card:hover,
+.achievement-card:hover {
+  transform: translateY(-6px) scale(1.01);
+  border-color: rgba(122, 227, 255, 0.38);
+}
+
+.card-image {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: calc(var(--radius-sm) - 10px);
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+}
+
+.card-placeholder {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: calc(var(--radius-sm) - 10px);
+  border: 1px dashed rgba(122, 227, 255, 0.35);
+  display: grid;
+  place-items: center;
+  color: rgba(122, 227, 255, 0.7);
+  font-size: 2rem;
+  background: rgba(10, 18, 32, 0.75);
+}
+
+.card-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 227, 255, 0.3);
+  background: rgba(122, 227, 255, 0.14);
+  color: var(--text-primary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  transition: transform var(--trans-fast), background var(--trans-fast), border-color var(--trans-fast);
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  background: rgba(122, 227, 255, 0.28);
+  border-color: rgba(122, 227, 255, 0.45);
+}
+
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.publication-card {
+  padding: 1.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(10, 18, 32, 0.62);
+  border: 1px solid rgba(122, 227, 255, 0.18);
+  transition: transform var(--trans-fast), border-color var(--trans-fast);
+}
+
+.publication-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(122, 227, 255, 0.36);
+}
+
+.publication-card h3 {
+  font-size: 1.15rem;
+  margin-bottom: 0.5rem;
+}
+
+.publication-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(122, 227, 255, 0.8);
+  margin-bottom: 0.85rem;
+}
+
+.courses-skills {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+#courses-list {
+  padding: 2rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.course-card {
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-sm);
+  background: rgba(10, 18, 32, 0.58);
+  border: 1px solid rgba(122, 227, 255, 0.2);
+  transition: transform var(--trans-fast), border-color var(--trans-fast);
+}
+
+.course-card:hover {
+  transform: translateX(6px);
+  border-color: rgba(122, 227, 255, 0.4);
+}
+
+#skills-cloud {
+  padding: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-content: flex-start;
+}
+
+.skill-pill {
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 227, 255, 0.28);
+  background: rgba(122, 227, 255, 0.14);
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  transition: transform var(--trans-fast), background var(--trans-fast);
+}
+
+.skill-pill img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+}
+
+.skill-pill:hover {
+  transform: translateY(-2px);
+  background: rgba(122, 227, 255, 0.26);
+}
+
+.footer {
+  padding: 2.5rem clamp(1.5rem, 4vw, 4rem) 3.5rem;
+  text-align: center;
+  color: rgba(245, 247, 255, 0.6);
+  position: relative;
+}
+
+.back-to-top {
+  position: fixed;
+  right: 2rem;
+  bottom: 2rem;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: rgba(122, 227, 255, 0.18);
+  border: 1px solid rgba(122, 227, 255, 0.35);
+  color: var(--text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+  transition: transform var(--trans-fast), background var(--trans-fast);
+}
+
+.back-to-top:hover {
+  background: rgba(122, 227, 255, 0.28);
+  transform: translateY(-4px);
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 600ms ease, transform 600ms ease;
+}
+
+.fade-in.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 980px) {
+  .hero-content {
+    grid-template-columns: 1fr;
+  }
+
+  .map-card {
+    order: -1;
+  }
+}
+
+@media (max-width: 820px) {
+  .nav {
+    border-radius: 24px;
+  }
+
+  .nav-links {
+    position: fixed;
+    inset: 5rem 1.5rem auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.5rem;
+    border-radius: 24px;
+    background: rgba(8, 14, 26, 0.95);
+    border: 1px solid rgba(122, 227, 255, 0.25);
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.35);
+    transform: translateY(-20px) scale(0.98);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--trans-fast), transform var(--trans-fast);
+  }
+
+  .nav-links.open {
+    opacity: 1;
+    pointer-events: all;
+    transform: translateY(0) scale(1);
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 540px) {
+  body {
+    font-size: 0.95rem;
+  }
+
+  .nav {
+    padding: 0.65rem 1rem;
+  }
+
+  .hero {
+    padding-top: 1.5rem;
+  }
+
+  .hero-card,
+  .map-card,
+  .news-column,
+  #courses-list,
+  #skills-cloud {
+    padding: 1.5rem;
+  }
+
+  .back-to-top {
+    right: 1rem;
+    bottom: 1.2rem;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,454 @@
+const dataFiles = {
+  about: '_data/aboutme.yml',
+  news: '_data/news.yml',
+  experience: '_data/experience.yml',
+  projects: '_data/projects.yml',
+  publications: '_data/publications.yml',
+  patents: '_data/patents.yml',
+  courses: '_data/courses.yml',
+  skills: '_data/skills.yml'
+};
+
+const keywordPalette = [
+  { key: 'paper', label: 'Publications' },
+  { key: 'model', label: 'AI Models' },
+  { key: 'award', label: 'Awards' },
+  { key: 'accepted', label: 'Conferences' },
+  { key: 'released', label: 'Releases' }
+];
+
+async function loadYaml(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Failed to load ${path}`);
+  }
+  const text = await response.text();
+  return jsyaml.load(text);
+}
+
+function createElement(tag, options = {}) {
+  const el = document.createElement(tag);
+  if (options.className) el.className = options.className;
+  if (options.html) el.innerHTML = options.html;
+  if (options.text) el.textContent = options.text;
+  if (options.attrs) {
+    Object.entries(options.attrs).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        el.setAttribute(key, value);
+      }
+    });
+  }
+  return el;
+}
+
+function parseMarkdownLinks(text = '') {
+  if (!text) return '';
+  return text
+    .replace(/\n/g, '<br>')
+    .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+}
+
+function renderBio(about) {
+  const bioCard = document.getElementById('bio-card');
+  const mapCard = document.getElementById('map-card');
+
+  const bioHeader = createElement('div', { className: 'bio-header fade-in' });
+  const avatar = createElement('img', {
+    attrs: { src: about['DP_Link'], alt: `${about['Name']} portrait` }
+  });
+  avatar.addEventListener('error', () => {
+    const initials = (about['Name'] || '')
+      .split(' ')
+      .filter(Boolean)
+      .map(part => part[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
+    const fallback = createElement('div', {
+      className: 'avatar-fallback',
+      text: initials || 'RL'
+    });
+    avatar.replaceWith(fallback);
+  }, { once: true });
+  const heading = createElement('div');
+  heading.innerHTML = `
+    <h1>${about['Name']}<span>${about['Area_Of_Expertise'] ?? ''}</span></h1>
+  `;
+
+  bioHeader.append(avatar, heading);
+
+  const aboutText = createElement('p', {
+    className: 'bio-description fade-in',
+    html: parseMarkdownLinks(about['About'])
+  });
+
+  const socials = createElement('div', { className: 'socials fade-in' });
+  const socialEntries = [
+    { icon: 'fa-brands fa-github', label: 'GitHub', url: about['Github'] },
+    { icon: 'fa-brands fa-linkedin', label: 'LinkedIn', url: about['LinkedIn'] },
+    { icon: 'fa-solid fa-envelope', label: 'Email', url: about['Email'] },
+    { icon: 'fa-brands fa-x-twitter', label: 'X', url: about['Twitter'] },
+    { icon: 'fa-solid fa-graduation-cap', label: 'Scholar', url: about['Scholar'] }
+  ];
+
+  socialEntries
+    .filter(item => item.url && item.url !== '#')
+    .forEach(item => {
+      const link = createElement('a', {
+        className: 'button',
+        attrs: { href: item.url, target: '_blank', rel: 'noopener' }
+      });
+      link.innerHTML = `<i class="${item.icon}"></i>${item.label}`;
+      socials.appendChild(link);
+    });
+
+  bioCard.append(bioHeader, aboutText, socials);
+
+  if (about['Map_Location_Link']) {
+    const iframe = createElement('iframe', {
+      attrs: {
+        src: about['Map_Location_Link'],
+        loading: 'lazy',
+        referrerpolicy: 'no-referrer-when-downgrade',
+        allowfullscreen: ''
+      }
+    });
+    const locationText = parseMarkdownLinks(about['Work_Location']);
+    const location = createElement('div', {
+      className: 'fade-in',
+      html: `<h3>Workspace</h3><p class="section-subtitle">${locationText ?? ''}</p>`
+    });
+    mapCard.append(location, iframe);
+  }
+}
+
+function renderNews(newsData) {
+  const latestList = document.getElementById('news-latest-list');
+  const archiveList = document.getElementById('news-archive-list');
+  const filtersRow = document.getElementById('news-filters');
+
+  const { k = 6, news = [] } = newsData ?? {};
+  const latest = news.slice(0, k);
+  const archive = news.slice(k);
+
+  const allChip = createElement('button', {
+    className: 'chip active',
+    text: 'All',
+    attrs: { 'data-keyword': 'all' }
+  });
+  allChip.addEventListener('click', () => {
+    document.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+    allChip.classList.add('active');
+    populateNewsList(latestList, latest);
+    populateNewsList(archiveList, archive);
+  });
+  filtersRow.appendChild(allChip);
+
+  keywordPalette.forEach(keyword => {
+    const chip = createElement('button', {
+      className: 'chip',
+      text: keyword.label,
+      attrs: { 'data-keyword': keyword.key }
+    });
+    chip.addEventListener('click', () => {
+      document.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+      chip.classList.add('active');
+      applyNewsFilter(keyword.key, latest, archive, latestList, archiveList);
+    });
+    filtersRow.appendChild(chip);
+  });
+
+  populateNewsList(latestList, latest);
+  populateNewsList(archiveList, archive);
+}
+
+function populateNewsList(container, items) {
+  container.innerHTML = '';
+  items.forEach(item => {
+    const card = createElement('article', { className: 'news-card fade-in' });
+    const time = createElement('time', { text: item.date });
+    const description = createElement('p', { html: parseMarkdownLinks(item.description) });
+    card.append(time, description);
+    container.appendChild(card);
+  });
+}
+
+function applyNewsFilter(keyword, latest, archive, latestContainer, archiveContainer) {
+  if (!keyword) return;
+  const filterItems = items =>
+    items.filter(item => (item.description ?? '').toLowerCase().includes(keyword));
+  populateNewsList(latestContainer, filterItems(latest));
+  populateNewsList(archiveContainer, filterItems(archive));
+}
+
+function renderExperience(entries) {
+  const timeline = document.getElementById('experience-timeline');
+  entries.forEach(entry => {
+    const item = createElement('div', { className: 'timeline-item fade-in' });
+    const dot = createElement('div', { className: 'timeline-dot' });
+    const card = createElement('div', { className: 'timeline-card' });
+
+    const title = createElement('h3');
+    title.innerHTML = entry.url
+      ? `<a href="${entry.url}" target="_blank" rel="noopener">${entry.company}</a>`
+      : entry.company;
+    const role = createElement('span', { className: 'section-subtitle', text: entry.title ?? '' });
+    title.appendChild(role);
+
+    const meta = createElement('div', { className: 'timeline-meta' });
+    if (entry.date) meta.appendChild(createElement('span', { text: entry.date }));
+    if (entry.location) meta.appendChild(createElement('span', { text: entry.location }));
+
+    const description = createElement('p', { html: parseMarkdownLinks(entry.description) });
+
+    card.append(title, meta, description);
+    item.append(dot, card);
+    timeline.appendChild(item);
+  });
+}
+
+function renderProjects(projects) {
+  const grid = document.getElementById('projects-grid');
+  projects.forEach(project => {
+    const card = createElement('article', { className: 'project-card fade-in' });
+
+    if (project.image) {
+      const img = createElement('img', {
+        className: 'card-image',
+        attrs: { src: project.image, alt: `${project.title} visual`, loading: 'lazy' }
+      });
+      img.addEventListener('error', () => {
+        img.remove();
+        const placeholder = createElement('div', {
+          className: 'card-placeholder',
+          html: '<i class="fa-solid fa-diagram-project"></i>'
+        });
+        card.prepend(placeholder);
+      }, { once: true });
+      card.appendChild(img);
+    }
+
+    const title = createElement('h3', { text: project.title });
+    const summary = createElement('p', {
+      className: 'section-subtitle',
+      html: parseMarkdownLinks(project.abstract)
+    });
+
+    const actions = createElement('div', { className: 'card-actions' });
+    [
+      { label: 'Paper', icon: 'fa-regular fa-file-lines', url: project.paper },
+      { label: 'Video', icon: 'fa-solid fa-circle-play', url: project.video },
+      { label: 'Code', icon: 'fa-brands fa-github', url: project.github }
+    ].forEach(link => {
+      if (link.url && link.url.trim() && link.url !== '#') {
+        const button = createElement('a', {
+          className: 'button',
+          attrs: { href: link.url, target: '_blank', rel: 'noopener' }
+        });
+        button.innerHTML = `<i class="${link.icon}"></i>${link.label}`;
+        actions.appendChild(button);
+      }
+    });
+
+    card.append(title, summary, actions);
+    grid.appendChild(card);
+  });
+}
+
+function renderPublications(publications) {
+  const stack = document.getElementById('publications-stack');
+  publications
+    .filter(item => typeof item === 'object' && item.paper)
+    .forEach(item => {
+      const card = createElement('article', { className: 'publication-card fade-in' });
+      const title = createElement('h3', { text: item.paper });
+      const meta = createElement('div', { className: 'publication-meta' });
+      if (item.pub) meta.appendChild(createElement('span', { text: item.pub }));
+      if (item.type) meta.appendChild(createElement('span', { text: item.type }));
+      if (item.author) meta.appendChild(createElement('span', { text: item.author }));
+
+      const actions = createElement('div', { className: 'card-actions' });
+      [
+        { label: 'Paper', icon: 'fa-regular fa-file-lines', url: item.paper_link },
+        { label: 'Project', icon: 'fa-solid fa-globe', url: item.project_page },
+        { label: 'Code', icon: 'fa-brands fa-github', url: item.code_link },
+        { label: 'BibTeX', icon: 'fa-solid fa-quote-right', url: item.bibtex },
+        { label: 'Video', icon: 'fa-solid fa-circle-play', url: item.video }
+      ].forEach(link => {
+        if (link.url && link.url.trim() && link.url !== '#') {
+          const button = createElement('a', {
+            className: 'button',
+            attrs: { href: link.url, target: '_blank', rel: 'noopener' }
+          });
+          button.innerHTML = `<i class="${link.icon}"></i>${link.label}`;
+          actions.appendChild(button);
+        }
+      });
+
+      card.append(title, meta, actions);
+      stack.appendChild(card);
+    });
+}
+
+function renderAchievements(patents, newsData) {
+  const grid = document.getElementById('achievements-grid');
+  const notableKeywords = ['accepted', 'released', 'awarded', 'winner', 'spotlight', 'joined', 'delivered'];
+  const notableNews = (newsData.news || []).filter(item =>
+    notableKeywords.some(keyword => (item.description ?? '').toLowerCase().includes(keyword))
+  ).slice(0, 8);
+
+  patents.forEach(patent => {
+    const card = createElement('article', { className: 'achievement-card fade-in' });
+    card.appendChild(createElement('h3', { text: patent.patent }));
+    const meta = createElement('p', {
+      className: 'section-subtitle',
+      html: `${patent.author ?? ''}<br><small>${patent.issued ?? ''} • ${patent.number ?? ''}</small>`
+    });
+
+    const actions = createElement('div', { className: 'card-actions' });
+    [
+      { label: 'Patent File', icon: 'fa-regular fa-file-lines', url: patent.file },
+      { label: 'Demo', icon: 'fa-solid fa-circle-play', url: patent.video }
+    ].forEach(link => {
+      if (link.url && link.url.trim() && link.url !== '#') {
+        const button = createElement('a', {
+          className: 'button',
+          attrs: { href: link.url, target: '_blank', rel: 'noopener' }
+        });
+        button.innerHTML = `<i class="${link.icon}"></i>${link.label}`;
+        actions.appendChild(button);
+      }
+    });
+
+    card.append(meta, actions);
+    grid.appendChild(card);
+  });
+
+  notableNews.forEach(item => {
+    const card = createElement('article', { className: 'achievement-card fade-in' });
+    card.appendChild(createElement('h3', { text: `Highlight — ${item.date}` }));
+    card.appendChild(createElement('p', {
+      className: 'section-subtitle',
+      html: parseMarkdownLinks(item.description)
+    }));
+    grid.appendChild(card);
+  });
+}
+
+function renderCourses(courses) {
+  const container = document.getElementById('courses-list');
+  courses.forEach(course => {
+    const card = createElement('div', { className: 'course-card fade-in' });
+    card.appendChild(createElement('h3', { text: course.title }));
+
+    const metaParts = [];
+    if (course.source) {
+      if (course.source_url) {
+        metaParts.push(`<a href="${course.source_url}" target="_blank" rel="noopener">${course.source}</a>`);
+      } else {
+        metaParts.push(course.source);
+      }
+    }
+    if (course.instructor) {
+      if (course.instructor_url) {
+        metaParts.push(`<a href="${course.instructor_url}" target="_blank" rel="noopener">${course.instructor}</a>`);
+      } else {
+        metaParts.push(course.instructor);
+      }
+    }
+
+    if (metaParts.length) {
+      card.appendChild(createElement('p', {
+        className: 'section-subtitle',
+        html: metaParts.join(' • ')
+      }));
+    }
+
+    if (course.certificate && course.certificate !== '#') {
+      const button = createElement('a', {
+        className: 'button',
+        attrs: { href: course.certificate, target: '_blank', rel: 'noopener' }
+      });
+      button.innerHTML = '<i class="fa-solid fa-award"></i>Certificate';
+      card.appendChild(createElement('div', { className: 'card-actions' })).appendChild(button);
+    }
+
+    container.appendChild(card);
+  });
+}
+
+function renderSkills(skills) {
+  const container = document.getElementById('skills-cloud');
+  skills.forEach(skill => {
+    const pill = createElement('div', { className: 'skill-pill fade-in' });
+    if (skill.image) {
+      const img = createElement('img', { attrs: { src: skill.image, alt: `${skill.name} icon`, loading: 'lazy' } });
+      img.addEventListener('error', () => img.remove(), { once: true });
+      pill.appendChild(img);
+    }
+    pill.appendChild(createElement('span', { text: skill.name }));
+    container.appendChild(pill);
+  });
+}
+
+function setupNavToggle() {
+  const toggle = document.querySelector('.nav-toggle');
+  const links = document.querySelector('.nav-links');
+  toggle.addEventListener('click', () => {
+    links.classList.toggle('open');
+  });
+  links.querySelectorAll('a').forEach(anchor => {
+    anchor.addEventListener('click', () => links.classList.remove('open'));
+  });
+}
+
+function setupScrollAnimations() {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, {
+    threshold: 0.2,
+    rootMargin: '0px 0px -50px 0px'
+  });
+
+  document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+}
+
+function updateFooterYear() {
+  document.getElementById('footer-year').textContent = new Date().getFullYear();
+}
+
+async function init() {
+  try {
+    const [about, news, experience, projects, publications, patents, courses, skills] = await Promise.all([
+      loadYaml(dataFiles.about),
+      loadYaml(dataFiles.news),
+      loadYaml(dataFiles.experience),
+      loadYaml(dataFiles.projects),
+      loadYaml(dataFiles.publications),
+      loadYaml(dataFiles.patents),
+      loadYaml(dataFiles.courses),
+      loadYaml(dataFiles.skills)
+    ]);
+
+    renderBio(about);
+    renderNews(news);
+    renderExperience(experience);
+    renderProjects(projects);
+    renderPublications(publications);
+    renderAchievements(patents, news);
+    renderCourses(courses);
+    renderSkills(skills);
+    updateFooterYear();
+    setupNavToggle();
+    setupScrollAnimations();
+  } catch (error) {
+    console.error('Failed to initialise page', error);
+  }
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rohit Lal • Research Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/+U8vz0Uv6fRvW0Qb6Y9v8w6jzrWeNseyX2VINqbodZ4x0drfac+4cP2nZCk8w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+</head>
+<body>
+  <div class="aurora"></div>
+  <header class="hero" id="top">
+    <nav class="nav">
+      <div class="logo">RL</div>
+      <button class="nav-toggle" aria-label="Toggle navigation">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav-links">
+        <li><a href="#bio">Bio</a></li>
+        <li><a href="#news">News</a></li>
+        <li><a href="#experience">Experience</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#publications">Publications</a></li>
+        <li><a href="#achievements">Achievements</a></li>
+        <li><a href="#courses">Courses & Skills</a></li>
+      </ul>
+    </nav>
+    <div class="hero-content" id="bio">
+      <div class="hero-card glass" id="bio-card"></div>
+      <div class="map-card glass" id="map-card"></div>
+    </div>
+  </header>
+
+  <main>
+    <section class="section" id="news">
+      <div class="section-header">
+        <h2>News</h2>
+        <p class="section-subtitle">Latest highlights and archive</p>
+      </div>
+      <div class="news-wrapper">
+        <div class="glass news-column" id="news-latest">
+          <h3>Latest</h3>
+          <div class="chip-row" id="news-filters"></div>
+          <div class="card-list" id="news-latest-list"></div>
+        </div>
+        <div class="glass news-column" id="news-archive">
+          <h3>Archive</h3>
+          <details open>
+            <summary>View previous updates</summary>
+            <div class="card-list" id="news-archive-list"></div>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="experience">
+      <div class="section-header">
+        <h2>Experience</h2>
+        <p class="section-subtitle">A timeline of my research and leadership journey</p>
+      </div>
+      <div class="timeline" id="experience-timeline"></div>
+    </section>
+
+    <section class="section" id="projects">
+      <div class="section-header">
+        <h2>Projects</h2>
+        <p class="section-subtitle">Selected explorations in AI, robotics, and design</p>
+      </div>
+      <div class="grid" id="projects-grid"></div>
+    </section>
+
+    <section class="section" id="publications">
+      <div class="section-header">
+        <h2>Publications</h2>
+        <p class="section-subtitle">Peer-reviewed research, workshops, and journals</p>
+      </div>
+      <div class="stack" id="publications-stack"></div>
+    </section>
+
+    <section class="section" id="achievements">
+      <div class="section-header">
+        <h2>Achievements &amp; Patents</h2>
+        <p class="section-subtitle">Recognitions, awards, and intellectual property</p>
+      </div>
+      <div class="grid" id="achievements-grid"></div>
+    </section>
+
+    <section class="section" id="courses">
+      <div class="section-header">
+        <h2>Courses &amp; Skills</h2>
+        <p class="section-subtitle">Continuous learning and technical toolkit</p>
+      </div>
+      <div class="courses-skills">
+        <div class="glass" id="courses-list"></div>
+        <div class="glass" id="skills-cloud"></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>Crafted with curiosity • © <span id="footer-year"></span> Rohit Lal</p>
+    <a class="back-to-top" href="#top" aria-label="Back to top">
+      <i class="fa-solid fa-arrow-up"></i>
+    </a>
+  </footer>
+
+  <script src="assets/js/main.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new single-page research portfolio that maps all YAML data sources into glassmorphic sections
- author responsive styling inspired by iOS liquid glass aesthetics with animated cards, chips, and placeholders
- implement a JavaScript loader that fetches YAML content, powers filters, and supplies graceful fallbacks for missing assets

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e3569c215483339ba2dcbb18a14c5d